### PR TITLE
Don't escape command if it's just '*', to fix the '*' command firing

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,9 @@ Cli.prototype.close = function () {
 Cli.prototype.command = function (cmd, desc, args, fn) {
     var c = new command(cmd, desc, args, fn);
     var p = c.cmd;
-    p = p.replace('?', '\\?').replace('$', '\\$').replace('+', '\\+').replace('^', '\\^').replace('*', '\\*');
+    if (p != '*') {
+      p = p.replace('?', '\\?').replace('$', '\\$').replace('+', '\\+').replace('^', '\\^').replace('*', '\\*');
+    }
     for (var prop in args) {
         if (args.hasOwnProperty(prop)) {
             var regex = new RegExp('{' + prop + '}', 'g');


### PR DESCRIPTION
This is a fix for https://github.com/kucoe/cline/issues/5