### PR TITLE
Adds "trim" mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,6 +192,14 @@ Cli.prototype.setPrompt = function (promptStr) {
     this._prompt = promptStr;
     return this._prompt;
 }
+/**
+ *
+ * set whether to trim input strings
+ *
+ */
+Cli.prototype.setTrim = function (trim) {
+    this._trim = trim
+}
 
 Cli.prototype.ask = function (str, mask, fn) {
     var stream = this.stream;
@@ -210,8 +218,8 @@ Cli.prototype.ask = function (str, mask, fn) {
             line = this._buf;
             this._buf = '';
         }
-        var val = line.trim();
-        if (!val.length) {
+        var val = line;
+        if (!val.trim().length) {
             this.ask(str, mask, fn);
         } else {
             defaultFn.call(this, val, fn);
@@ -286,8 +294,11 @@ Cli.prototype.command = function (cmd, desc, args, fn) {
 Cli.prototype.parse = function (str) {
     var resp = null;
     var self = this;
+    if (this._trim !== false) {
+        str = str.trim();
+    }
     this.commands.map(function (prop, val) {
-        var regex = new RegExp('^' + prop + '$');
+        var regex = new RegExp('^\\s*' + prop + '\\s*$');
         if (str.match(regex)) {
             var matches = regex.exec(str);
             var main = matches.shift();

--- a/index.js
+++ b/index.js
@@ -213,16 +213,17 @@ Cli.prototype.ask = function (str, mask, fn) {
     if (this.mask != undefined) {
         this._buf = '';
     }
+    self = this
     this.fn = function (line) {
         if (this._buf) {
             line = this._buf;
             this._buf = '';
         }
         var val = line;
-        if (!val.trim().length) {
+        if (self._trim !== false && !val.trim().length) {
             this.ask(str, mask, fn);
         } else {
-            defaultFn.call(this, val, fn);
+            defaultFn.call(this, line, fn);
         }
     };
     stream.prompt();
@@ -321,8 +322,8 @@ Cli.prototype.parse = function (str) {
                 }
             }
             var fn = val.listener;
-            resp = (fn ? fn(main, args) : true) || true;
-            self.emit('command', main, val.cmd, args);
+            resp = (fn ? fn(str, args) : true) || true;
+            self.emit('command', str, val.cmd, args);
             return false;
         }
         return true;

--- a/tests.js
+++ b/tests.js
@@ -189,6 +189,24 @@ if (module == require.main) {
             });
             cli.parse('#12');
         });
+        describe('trim mode', function (done) {
+          it('unset should trim spaces', function (done) {
+            cli.command('*', function (input) {
+                input.should.eql('unindented', 'unindented input');
+                done();
+            })
+            cli.parse('  unindented');
+          })
+          it('set should not trim spaces', function (done) {
+            cli.setTrim(false);
+            cli.command('*', function (input) {
+                input.should.eql('  indented', 'indented input');
+                done();
+            })
+            cli.parse('  indented');
+          })
+        })
+
 	it('should respect special chars', function (done) {
             cli.command('?{number}+{cmd}$', 'task command by number', {number: '\\d{1,3}', cmd: 'x|\\+|-|'}, function (input, args) {
                 args.number.should.eql(12, 'number');


### PR DESCRIPTION
Two changes:

1) command sends original input string (not parsed match) as first parameter to callback and listener (corresponds to documentation).
2) adds a "trim" mode. Default "on" corresponds to current behavior. If explicitly turned off via "setTrim(false)", then input strings are not trimmed before matching, and blank lines are not skipped in ask.

Motivation: I wanted to write a interpreter for a mini-language that supported line continuation a little like python's: if a line ends in ":" then subsequent lines with leading spaces were treated as part of first line.

I implemented this as a "continuation mode" which I'd explicitly switch into when I matched a ":"-ending command. This had a catch-all command looked for line without blanks before finishing processing on whole.

Unfortunately, this didn't work as (though doc seems to indicate otherwise) I didn't get original input back in "command".
